### PR TITLE
Change implementation of `add-spacing-if-enabled`

### DIFF
--- a/rubby.typ
+++ b/rubby.typ
@@ -21,12 +21,8 @@
   }
 
   let add-spacing-if-enabled(text) = {
-    if auto-spacing != true { return text }
-    return (
-      if text.first() != delimiter { delimiter }
-      + text
-      + if text.last() != delimiter { delimiter }
-    )
+    if auto-spacing != true or text.first() != delimiter or text.last() != delimiter { return text }
+    return delimiter + text + delimiter
   }
 
   let rt-array = if type(rt) == content {


### PR DESCRIPTION
Currently, writing `#ruby[か|][変|える]` while enabling `auto-spacing` returns an error. This is due to the function [`add-spacing-if-enabled`](https://github.com/Andrew15-5/rubby/blob/40c1ed3199d3d94f73f5e278c9d4c50c12945c7f/rubby.typ#L23-L30) transforming `か|` and `変|える` into `|か|` and `|変|える|` respectively.

The new implementation only adds delimiters when no delimiter is present on either side of the text, so `か|` should now become `|か||` as expected.